### PR TITLE
iOS: Xcode 26 で arm64 simulator 対応の opencv2.xcframework をビルド可能にする

### DIFF
--- a/3rdparty/libpng/pngpriv.h
+++ b/3rdparty/libpng/pngpriv.h
@@ -518,8 +518,15 @@
 #  include <float.h>
 
 #  if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
-    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
-   /* We need to check that <math.h> hasn't already been included earlier
+    defined(THINK_C) || defined(__SC__)
+   /* Classic Mac OS compilers only. `TARGET_OS_MAC` has been intentionally
+    * dropped here: in modern Apple SDKs (macOS/iOS/tvOS/watchOS) it is
+    * always defined as 1 and no longer implies "Classic Mac OS", which
+    * wrongly enabled the <fp.h> branch and broke builds on Xcode 26 for
+    * iOS where <fp.h> is absent. Modern Apple platforms fall through to
+    * <math.h> below via __APPLE__/__MACH__ compilers.
+    *
+    * We need to check that <math.h> hasn't already been included earlier
     * as it seems it doesn't agree with <fp.h>, yet we should really use
     * <fp.h> if possible.
     */

--- a/3rdparty/zlib/zutil.h
+++ b/3rdparty/zlib/zutil.h
@@ -137,7 +137,14 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+/* Classic Mac OS only. `TARGET_OS_MAC` has been intentionally dropped
+ * here: in modern Apple SDKs (macOS/iOS/tvOS/watchOS) it is always
+ * defined as 1 and no longer implies "Classic Mac OS", which wrongly
+ * defined `fdopen` to `NULL` on iOS and broke the system `<stdio.h>`
+ * prototype of `fdopen()` with Xcode 26 iPhoneOS/iPhoneSimulator SDK.
+ * On modern Apple, `fdopen()` is a normal POSIX function.
+ */
+#if defined(MACOS)
 #  define OS_CODE  7
 #  ifndef Z_SOLO
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ brew install cmake
 # --<platform>_archs <arch> : 指定したプラットフォーム, アーキテクチャのみ含める
 # --build_only_specified_archs : 未指定のプラットフォームを含めない
 # --without <module> : 指定したモジュールを含めずにビルドを行う
-# note: pythonコマンドが使えないと失敗する。python3ではNG。
-python opencv/platforms/apple/build_xcframework.py --out ./build_xcframework --iphoneos_archs "arm64" --iphonesimulator_archs "x86_64,arm64" --build_only_specified_archs --without videoio --without video --without ts  --without python --without objdetect --without js --without java --without gapi --without dnn --without photo --iphoneos_deployment_target 14.0
+# note: 近年の macOS には `python` (Python 2) が同梱されていないため `python3` を使う。
+# note: `--iphoneos_deployment_target` は Apps-iOS 側の `IPHONEOS_DEPLOYMENT_TARGET = 16.0` に合わせる。
+#       14.0 / 15.0 を指定すると Xcode 26 系の iPhoneOS SDK ヘッダと整合せず `_stdio.h` 付近でビルドが失敗する。
+python3 opencv/platforms/apple/build_xcframework.py --out ./build_xcframework --iphoneos_archs "arm64" --iphonesimulator_archs "x86_64,arm64" --build_only_specified_archs --without videoio --without video --without ts  --without python --without objdetect --without js --without java --without gapi --without dnn --without photo --iphoneos_deployment_target 16.0
 ```
 
 zipコマンドで圧縮し、releaseページにアップロードしてください。

--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -444,6 +444,41 @@ class Builder:
                     if filestem in platform_name_map:
                         os.rename(os.path.join(dirname, filename), os.path.join(dirname, platform_name_map[filestem] + fileext))
 
+            # Fat framework needs a <name>-Swift.h that works for every slice.
+            # Each arch's <name>-Swift.h is guarded by `#if defined(__<ARCH>__)` only for
+            # that arch, so the copy from builddirs[0] above is incomplete on the
+            # other arches (e.g. `#error unsupported Swift architecture`). Emit a
+            # per-arch bridging header and a tiny router that includes the right
+            # one at preprocessing time.
+            arch_macro_map = {
+                "arm": "__arm__",
+                "arm64": "__arm64__",
+                "i386": "__i386__",
+                "x86_64": "__x86_64__",
+            }
+            swift_header_fname = name + "-Swift.h"
+            per_arch_headers = []  # list of (cpp_macro, per_arch_filename)
+            for d in builddirs:
+                src = os.path.join(d, "install", "lib", name + ".framework", "Headers", swift_header_fname)
+                if not os.path.exists(src):
+                    continue
+                target = d[(d.rfind("build-") + 6):]
+                arch = target[:target.rfind("-")]
+                if arch not in arch_macro_map:
+                    continue
+                per_arch_fname = "%s-%s-Swift.h" % (name, arch)
+                shutil.copyfile(src, os.path.join(dstdir, "Headers", per_arch_fname))
+                per_arch_headers.append((arch_macro_map[arch], per_arch_fname))
+
+            if len(per_arch_headers) >= 2:
+                router_path = os.path.join(dstdir, "Headers", swift_header_fname)
+                with codecs.open(router_path, "w", "utf-8") as out:
+                    out.write("#if 0\n")
+                    for macro, fname in per_arch_headers:
+                        out.write("#elif defined(%s) && %s\n" % (macro, macro))
+                        out.write("# include \"%s\"\n" % fname)
+                    out.write("#else\n#error unsupported Swift architecture\n#endif\n")
+
         # make universal static lib
         if self.dynamic:
             libs = [os.path.join(d, "install", "lib", name + ".framework", name) for d in builddirs]


### PR DESCRIPTION
## 背景

[t-clue/Apps-iOS#4805](https://github.com/t-clue/Apps-iOS/issues/4805) および [t-clue/Apps-iOS#5755](https://github.com/t-clue/Apps-iOS/pull/5755) の一環。

Apps-iOS では Apple Silicon + Rosetta を廃し、iOS Simulator を **native arm64** で動かす方向に進めている。DJI SDK XCFramework は [Apps-iOS-Pods PR #9](https://github.com/t-clue/Apps-iOS-Pods/pull/9) で再生成済みだが、**`opencv2.xcframework`** が simulator の arm64 slice を Swift bridging header レベルで取り扱えないことが判明し、さらに **Xcode 26 系では OpenCV 4.8.0 同梱の libpng / zlib が `TARGET_OS_MAC` の誤用で iOS ビルド自体が不能**だったため、本 PR ではこれらを併せて解消する。

## 修正内容（コミット 4 本）

### 1. \`ios: merge per-arch Swift bridging headers in fat framework\`

**問題**: 既存の \`ios-arm64_x86_64-simulator/opencv2.framework/Headers/opencv2-Swift.h\` は以下の形式で、\`arm64\` simulator では \`#error unsupported Swift architecture\` に落ちる:

\`\`\`c
#if 0
#elif defined(__x86_64__) && __x86_64__
// ... (x86_64 専用の Swift bridging 宣言) ...
#else
#error unsupported Swift architecture
#endif
\`\`\`

**原因**: \`platforms/ios/build_framework.py\` の \`Builder.makeFramework()\` が Headers を **最初の arch の build dir (\`builddirs[0]\`) からのみ** コピーしており、arch 固有の \`<name>-Swift.h\` が他 arch 側に届かない。\`Modules/\` 側は全 arch 分コピー＋platform 名リネームが実装されているが、Headers 側のロジックが抜けていた。

**パッチ**: 各 arch の \`<name>-Swift.h\` を \`<name>-<arch>-Swift.h\` として \`Headers/\` に個別コピーし、最終 \`<name>-Swift.h\` を以下のルーターに差し替える:

\`\`\`c
#if 0
#elif defined(__arm64__) && __arm64__
# include "opencv2-arm64-Swift.h"
#elif defined(__x86_64__) && __x86_64__
# include "opencv2-x86_64-Swift.h"
#else
#error unsupported Swift architecture
#endif
\`\`\`

build dir の arch 抽出は既存の \`makeDynamicLib()\` の L342 と同手法。単一 arch ビルドでは何もしないので従来挙動を維持。

### 2. \`docs: update README build command for Xcode 26 / Apps-iOS\`

- \`python\` → \`python3\`（近年の macOS には Python 2 が同梱されないため）
- \`--iphoneos_deployment_target 14.0\` → **\`16.0\`**（Apps-iOS 側の \`IPHONEOS_DEPLOYMENT_TARGET = 16.0\` と揃える）

### 3. \`3rdparty/libpng: drop TARGET_OS_MAC guard for <fp.h>\`

**問題**: Xcode 26.3 + iPhoneOS/iPhoneSimulator SDK で

    3rdparty/libpng/pngpriv.h:527:16: fatal error: 'fp.h' file not found

**原因**: \`#if (... || defined(TARGET_OS_MAC))\` で \`<fp.h>\` を取り込む分岐があったが、モダン Apple SDK では \`TARGET_OS_MAC\` が macOS/iOS/tvOS/watchOS **全てで 1 定義**されるため iPhoneOS ビルドでも該当分岐に入ってしまう。Xcode 26 の Apple SDK には Classic Mac OS の \`<fp.h>\` が存在しない。

**パッチ**: \`TARGET_OS_MAC\` を条件から外す。Classic Mac OS コンパイラは残る 4 つのマクロ（\`__MWERKS__ && macintosh\` / \`applec\` / \`THINK_C\` / \`__SC__\`）で明示判定されているので、Classic Mac OS の既存挙動は壊れない。モダン Apple は \`#else\` 側の \`<math.h>\` にフォールスルーする。

### 4. \`3rdparty/zlib: drop TARGET_OS_MAC guard for fdopen stub\`

**問題**: libpng #3 を通してもさらに同根のエラーが発生:

    _stdio.h:322:7: error: expected identifier or '('
      322 | FILE *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(...)

**原因**: \`3rdparty/zlib/zutil.h\` が \`#if defined(MACOS) || defined(TARGET_OS_MAC)\` ブロック内で \`#define fdopen(fd,mode) NULL /* No fdopen() */\` を定義していた。これも \`TARGET_OS_MAC\` が全 Apple プラットフォームで 1 のため iOS 向けビルドで \`fdopen\` マクロが定義され、その後インクルードされるシステム \`<stdio.h>\` の \`fdopen()\` プロトタイプ宣言が token レベルで破壊される。

**パッチ**: 同じく \`TARGET_OS_MAC\` を条件から外し、\`MACOS\` のみで Classic Mac OS を判定する。

## 期待される成果

このパッチを適用して \`build_xcframework.py\` を Xcode 26.3 で走らせると、

1. iPhoneOS arm64 / iPhoneSimulator x86_64 / iPhoneSimulator arm64 の 3 slice が**全てビルド完走**する
2. \`ios-arm64_x86_64-simulator/opencv2.framework/Headers/\` に \`opencv2-arm64-Swift.h\`、\`opencv2-x86_64-Swift.h\`、およびルーターとしての \`opencv2-Swift.h\` が生成される
3. Apps-iOS 側で \`CLUEFoundation\` / \`DR-Debug\` / \`SK-Debug\` 等が **native arm64 simulator** 向けにビルド・テストできるようになる

## 検証

**Draft PR として先に上げ、検証は後追いで本 PR にコメント追記**する方針。確認予定:

1. Apple Silicon Mac (Xcode 26.3) でパッチ後の \`build_xcframework.py\` を実行し、生成物の \`opencv2.xcframework\` に上記構造のヘッダが入っていること
2. 生成物を \`t-clue/Apps-iOS-Carthage\` に差し替え、Apps-iOS PR #5755 のブランチで **native arm64 simulator** による \`RS-Debug\` / \`SK-Debug\` のユニットテストが通ること

検証完了後、本 PR を Ready for Review にする予定。

## 関連

- 動機 PR: [t-clue/Apps-iOS#5755](https://github.com/t-clue/Apps-iOS/pull/5755)
- 連動 PR: [t-clue/Apps-iOS-Pods#9](https://github.com/t-clue/Apps-iOS-Pods/pull/9)（DJI XCFramework 側の同等対応）
- 元 PR: [t-clue/Apps-iOS#5751](https://github.com/t-clue/Apps-iOS/pull/5751)

## リリース後のフロー

マージ後、\`opencv-4.8.0-ios-framework.zip\` を更新する予定:

1. 本リポジトリで Xcode 26.3 / macOS 15 環境にて README の手順通り \`build_xcframework.py\` を実行
2. 生成された \`opencv2.xcframework\` を zip 化し、**新しいリリースタグ**（例: \`4.8.0-t-clue-arm64-sim-1\`）として Release に添付
3. Apps-iOS の \`CarthageJsons/opencv2.json\` をそのタグへ更新
4. Apps-iOS-Carthage 側に新しい \`opencv2.xcframework\` バイナリをコミット